### PR TITLE
Make data pipeline clientlib dh-virtualenv 1.x compatible

### DIFF
--- a/debian/data-pipeline-tools.links
+++ b/debian/data-pipeline-tools.links
@@ -1,6 +1,6 @@
-usr/share/python/data-pipeline-tools/bin/data_pipeline_tailer usr/bin/data_pipeline_tailer
-usr/share/python/data-pipeline-tools/bin/data_pipeline_refresh_runner usr/bin/data_pipeline_refresh_runner
-usr/share/python/data-pipeline-tools/bin/data_pipeline_refresh_manager usr/bin/data_pipeline_refresh_manager
-usr/share/python/data-pipeline-tools/bin/data_pipeline_refresh_requester usr/bin/data_pipeline_refresh_requester
-usr/share/python/data-pipeline-tools/bin/data_pipeline_compaction_setter usr/bin/data_pipeline_compaction_setter
-usr/share/python/data-pipeline-tools/bin/data_pipeline_introspector usr/bin/data_pipeline_introspector
+opt/venvs/data-pipeline-tools/bin/data_pipeline_tailer usr/bin/data_pipeline_tailer
+opt/venvs/data-pipeline-tools/bin/data_pipeline_refresh_runner usr/bin/data_pipeline_refresh_runner
+opt/venvs/data-pipeline-tools/bin/data_pipeline_refresh_manager usr/bin/data_pipeline_refresh_manager
+opt/venvs/data-pipeline-tools/bin/data_pipeline_refresh_requester usr/bin/data_pipeline_refresh_requester
+opt/venvs/data-pipeline-tools/bin/data_pipeline_compaction_setter usr/bin/data_pipeline_compaction_setter
+opt/venvs/data-pipeline-tools/bin/data_pipeline_introspector usr/bin/data_pipeline_introspector

--- a/debian/rules
+++ b/debian/rules
@@ -6,6 +6,7 @@ export DH_VERBOSE=1
 
 # This has to be exported to make some magic below work.
 export DH_OPTIONS
+export DH_VIRTUALENV_INSTALL_ROOT=/opt/venvs
 
 %:
 	dh $@ --with python-virtualenv


### PR DESCRIPTION
See (internal): https://migration-status.dev.yelp.com/metric/DHVirtualenvUpgrade

Here's a similar branch from paasta: https://github.com/Yelp/paasta/pull/941